### PR TITLE
fix renderflow issue

### DIFF
--- a/lib/developers/groovin_chip/groovin_chip.dart
+++ b/lib/developers/groovin_chip/groovin_chip.dart
@@ -344,10 +344,9 @@ class _GroovinChipPageState extends State<GroovinChipPage> {
                           child: Row(
                             children: <Widget>[
                               Flexible(
-                              child:
-                              Text(
-                                "This package includes custom widgets built by me.",
-                              ),
+                                child: Text(
+                                  "This package includes custom widgets built by me.",
+                                ),
                               )
                             ],
                           ),

--- a/lib/developers/groovin_chip/groovin_chip.dart
+++ b/lib/developers/groovin_chip/groovin_chip.dart
@@ -343,9 +343,12 @@ class _GroovinChipPageState extends State<GroovinChipPage> {
                           padding: const EdgeInsets.only(top: 16.0, left: 12.0, right: 12.0),
                           child: Row(
                             children: <Widget>[
+                              Flexible(
+                              child:
                               Text(
                                 "This package includes custom widgets built by me.",
                               ),
+                              )
                             ],
                           ),
                         ),


### PR DESCRIPTION
On iOS simulator (iphone 8 - 11.4), one of the `text` widget was not rendered properly and was throwing an exception, as below:

![screen shot 2019-01-08 at 2 26 20 pm](https://user-images.githubusercontent.com/16548367/50847649-24828100-1398-11e9-9e3a-0903a25e2e52.png)

Fixed the issue by wrapping the said `text` widget inside `Flexible` widget. Updated screen:

![screen shot 2019-01-08 at 2 31 00 pm](https://user-images.githubusercontent.com/16548367/50847750-601d4b00-1398-11e9-9826-aa3227a91701.png)
